### PR TITLE
Add minimal workflow support

### DIFF
--- a/ecospheres_migrator/batch.py
+++ b/ecospheres_migrator/batch.py
@@ -1,12 +1,13 @@
 from dataclasses import dataclass
 
-from ecospheres_migrator.geonetwork import MefArchive
+from ecospheres_migrator.geonetwork import MefArchive, WorkflowState
 
 
 @dataclass(kw_only=True)
 class BatchRecord:
     uuid: str
     template: bool
+    state: WorkflowState | None
     original: str
 
 
@@ -39,5 +40,6 @@ class Batch:
         mef = MefArchive()
         for r in self.records:
             if isinstance(r, SuccessBatchRecord):
+                # TODO: state?
                 mef.add(r.uuid, r.result, r.info)
         return mef.finalize()

--- a/ecospheres_migrator/geonetwork.py
+++ b/ecospheres_migrator/geonetwork.py
@@ -2,6 +2,8 @@ import io
 import logging
 import zipfile
 from dataclasses import dataclass
+from enum import IntEnum, StrEnum, auto
+from typing import Any
 
 import requests
 from lxml import etree
@@ -11,11 +13,51 @@ logging.basicConfig(level=logging.DEBUG)
 log = logging.getLogger(__name__)
 
 
+class WorkflowStatus(IntEnum):
+    UNKNOWN = 0
+    DRAFT = 1
+    APPROVED = 2
+    RETIRED = 3
+    SUBMITTED = 4
+    REJECTED = 5
+
+
+class WorkflowStage(StrEnum):
+    NEVER_APPROVED = auto()
+    APPROVED = auto()
+    WORKING_COPY = auto()
+
+
+@dataclass
+class WorkflowState:
+    # [Stage]  NEVER_APPROVED ------> APPROVED <-> WORKING_COPY (WC)
+    # [Status] DRAFT -> SUBMITTED? -> APPROVED  -> DRAFT -> SUBMITTED? -\
+    #                -> REJECTED -\                      -> REJECTED -\  |
+    #                <------------/                      <------------/  |
+    #                                           <--- WC applied --------/|
+    #                                           <--- WC dropped --------/
+    #
+    # Each of those stages require a different treatment:
+    # - NEVER_APPROVED:
+    #   - Status is reported in `medatadata.mdStatus`.
+    #   - Updating a never-approved record updates the record itself.
+    # - APPROVED:
+    #   - Status is reported in `metadata.mdStatus` (= APPROVED).
+    #   - Updating an approved record creates a working copy containing the update.
+    # - WORKING_COPY:
+    #   - Working copy status must be queried from `/records/{uuid}/status`, since
+    #     `metadata.mdStatus` always reports the record status.
+    #   - Updating a record with a working copy MUST update the working copy.
+    stage: WorkflowStage
+    status: WorkflowStatus  # working copy status in WORKING_COPY stage, otherwise record status
+
+
 @dataclass
 class Record:
     uuid: str
     title: str
     template: bool
+    state: WorkflowState | None
 
 
 class GeonetworkClient:
@@ -65,11 +107,29 @@ class GeonetworkClient:
                 mds = [mds]
             recs = []
             for md in mds:
-                log.debug("Record:", md)
                 uuid = md["geonet:info"]["uuid"]
                 title = md.get("defaultTitle")
                 template = md.get("isTemplate") == "y"
-                recs.append(Record(uuid=uuid, title=title, template=template))
+                state = None
+                if "mdStatus" in md:  # workflow enabled
+                    if not md.get("draft") == "e":
+                        status = WorkflowStatus(int(md["mdStatus"]))
+                        stage = (
+                            WorkflowStage.APPROVED
+                            if status == WorkflowStatus.APPROVED
+                            else WorkflowStage.NEVER_APPROVED
+                        )
+                    else:
+                        # Not supported in migration().
+                        # We don't bother setting the status (requires an API call), but
+                        # still include it in `records` so we can report on it.
+                        stage = WorkflowStage.WORKING_COPY
+                        status = WorkflowStatus.UNKNOWN
+                    state = WorkflowState(stage=stage, status=status)
+                    log.debug(f"Workflow state: {state}")
+                rec = Record(uuid=uuid, title=title, template=template, state=state)
+                log.debug(f"Record: {rec}")
+                recs.append(rec)
             records += recs
             to = int(rsp.get("@to"))
 
@@ -85,7 +145,7 @@ class GeonetworkClient:
                 "increasePopularity": "false",
                 "withInfo": "true",
                 "attachment": "false",
-                "approved": "true",
+                "approved": "false",  # only relevant when workflow is enabled
             },
         )
         r.raise_for_status()
@@ -107,14 +167,16 @@ class GeonetworkClient:
         )
         r.raise_for_status()
 
-    def update_record(self, uuid: str, metadata: str, template: bool):
+    def update_record(
+        self, uuid: str, metadata: str, template: bool, state: WorkflowState | None = None
+    ):
         # PUT /records doesn't work as expected: it delete/recreates the record instead
         # of updating in place, hence losing Geonetwork-specific record metadata like
-        # workflow status or access rights.
+        # workflow state or access rights.
         # So instead we pretend to be the Geonetwork UI and "edit" the XML view of the
         # record, ignoring the returned editor view and immediately saving our new
         # metadata as the "edit" outcome.
-        log.debug(f"Updating record {uuid}: template={template}")
+        log.debug(f"Updating record {uuid}: template={template}, state={state}")
 
         r = self.session.get(
             f"{self.api}/records/{uuid}/editor",
@@ -127,7 +189,7 @@ class GeonetworkClient:
         r.raise_for_status()
 
         # API expects x-www-form-urlencoded here
-        data = {
+        data: dict[str, Any] = {
             "tab": "xml",
             "withAttributes": "false",
             "withValidationErrors": "false",
@@ -136,8 +198,35 @@ class GeonetworkClient:
             "template": "y" if template else "n",
             "data": metadata,
         }
+        if state:
+            if state.stage == WorkflowStage.WORKING_COPY:
+                raise NotImplementedError("Migrating working copies is not supported")
+            if state.status == WorkflowStatus.APPROVED:
+                # The /editor API endpoint rejects requests setting the record status
+                # directly to APPROVED (since it can't be done through the editor UI).
+                # This means updates of records in WorkflowStage.APPROVED have to go
+                # through creating a working copy.
+                # We create that working copy as SUBMITTED so the update will have more
+                # chances to get noticed (requiring action from a reviewer) in case the
+                # follow-up request to re-approve the record fails.
+                data["status"] = WorkflowStatus.SUBMITTED
+            else:
+                data["status"] = state.status
         r = self.session.post(f"{self.api}/records/{uuid}/editor", data=data)
         r.raise_for_status()
+
+        if state and state.stage == WorkflowStage.APPROVED:
+            # If the record was already approved, transparently approve the working copy
+            # we created above when updating the record.
+            r = self.session.put(
+                f"{self.api}/records/{uuid}/status",
+                headers={"Content-Type": "application/json"},
+                json={
+                    "changeMessage": "Approved by Migrator",
+                    "status": WorkflowStatus.APPROVED,
+                },
+            )
+            r.raise_for_status()
 
     def get_sources(self) -> dict:
         r = self.session.get(f"{self.api}/sources", headers={"Accept": "application/json"})

--- a/ecospheres_migrator/migrator.py
+++ b/ecospheres_migrator/migrator.py
@@ -5,7 +5,12 @@ from pathlib import Path
 from lxml import etree
 
 from ecospheres_migrator.batch import Batch, FailureBatchRecord, SuccessBatchRecord
-from ecospheres_migrator.geonetwork import GeonetworkClient, Record, extract_record_info
+from ecospheres_migrator.geonetwork import (
+    GeonetworkClient,
+    Record,
+    WorkflowStage,
+    extract_record_info,
+)
 from ecospheres_migrator.util import xml_to_string
 
 logging.basicConfig(level=logging.DEBUG)
@@ -53,7 +58,19 @@ class Migrator:
 
         batch = Batch()
         for r in selection:
+            log.debug(f"Processing {r.uuid} (template={r.template} state={r.state})")
             original = self.gn.get_record(r.uuid)
+            if r.state and r.state.stage == WorkflowStage.WORKING_COPY:
+                batch.add(
+                    FailureBatchRecord(
+                        uuid=r.uuid,
+                        template=r.template,
+                        state=r.state,
+                        original=xml_to_string(original),
+                        error="Record has a working copy",
+                    )
+                )
+                continue
             try:
                 info = extract_record_info(original, sources)
                 result = transform(original, CoupledResourceLookUp="'disabled'")
@@ -62,6 +79,7 @@ class Migrator:
                     SuccessBatchRecord(
                         uuid=r.uuid,
                         template=r.template,
+                        state=r.state,
                         original=xml_to_string(original),
                         result=xml_to_string(result),
                         info=xml_to_string(info),
@@ -72,6 +90,7 @@ class Migrator:
                     FailureBatchRecord(
                         uuid=r.uuid,
                         template=r.template,
+                        state=r.state,
                         original=xml_to_string(original),
                         error=str(e),
                     )
@@ -88,12 +107,13 @@ class Migrator:
         for r in batch.successes():
             try:
                 if overwrite:
-                    self.gn.update_record(r.uuid, r.result, template=r.template)
+                    self.gn.update_record(r.uuid, r.result, template=r.template, state=r.state)
                 else:
                     assert group is not None
                     # TODO: publish flag
                     self.gn.duplicate_record(r.uuid, r.result, template=r.template, group=group)
             except Exception:
+                # TODO: track failure cause like in transform()
                 failures.append(r.uuid)
 
         if failures:

--- a/ecospheres_migrator/templates/fragments/select_preview.html.j2
+++ b/ecospheres_migrator/templates/fragments/select_preview.html.j2
@@ -3,7 +3,7 @@
   {{ results|length }} résultat(s)
   <ul>
   {%- for result in results -%}
-    <li>{{ result.uuid }} [{{ "T" if result.template else "R"}}]: {{ result.title }}</li>
+    <li>{{ result.uuid }} [{{ "T" if result.template else "R" }}] [{{ "d" if (result.state and result.state.stage == "working_copy") else "-" }}{{ result.state.status if result.state else "-" }}]: {{ result.title }}</li>
   {%- endfor -%}
   </ul>
 {% else -%}


### PR DESCRIPTION
Fix #15 

On records with workflow enabled:
- record has no draft (working copy) -> proceed
- record has draft -> raise error

This is to avoid the flaky draft implementation in Geonetwork, at least for now.