### PR TITLE
feat: add diff

### DIFF
--- a/isomorphe/templates/diff.html.j2
+++ b/isomorphe/templates/diff.html.j2
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Écosphères ISOmorphe">
+    <meta name="keywords" content="ecospheres, geonetwork, iso-19139">
+    <title>ISOmorphe diff</title>
+    <link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/npm/diff2html/bundles/css/diff2html.min.css" />
+  </head>
+  <body>
+    <main role="main" id="content">
+      <div id="diff-content"></div>
+    </main>
+    <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/diff2html/bundles/js/diff2html-ui.min.js"></script>
+    <script type="text/javascript">
+    const targetElement = document.getElementById('diff-content');
+    const configuration = {
+      drawFileList: false,
+      matching: 'lines',
+      inputFormat: 'diff',
+      outputFormat: 'side-by-side',
+      synchronisedScroll: true,
+      fileContentToggle: false,
+    };
+    const diff2htmlUi = new Diff2HtmlUI(targetElement, `{{ diff }}`, configuration);
+    diff2htmlUi.draw();
+    </script>
+  </body>
+</html>

--- a/isomorphe/templates/fragments/transform_job_status.html.j2
+++ b/isomorphe/templates/fragments/transform_job_status.html.j2
@@ -136,6 +136,7 @@
                       <th scope="col">Fiche originale</th>
                       <th scope="col">XML original</th>
                       <th scope="col">XML transformé</th>
+                      <th scope="col">Différences</th>
                       <th scope="col">Avertissements</th>
                     </tr>
                   </thead>
@@ -158,6 +159,11 @@
                           <a href="{{ url_for('transform_result', job_id=job.id, uuid=record.uuid) }}"
                             target="_blank"
                             rel="noopener">Voir le XML</a>
+                        </td>
+                        <td>
+                          <a href="{{ url_for('transform_diff', job_id=job.id, uuid=record.uuid) }}"
+                            target="_blank"
+                            rel="noopener">Voir le diff</a>
                         </td>
                         <td>
                           {{ record | record_transform_log }}

--- a/isomorphe/util.py
+++ b/isomorphe/util.py
@@ -4,4 +4,5 @@ XML_FORMAT = {"encoding": "utf-8", "pretty_print": True, "xml_declaration": True
 
 
 def xml_to_string(tree: etree._ElementTree, format: dict = XML_FORMAT):
+    etree.indent(tree, space=" ")
     return etree.tostring(tree, **format)


### PR DESCRIPTION
Fix #79 

Tentatively integrates https://diff2html.xyz/ for result vs original diff for a transform job record.

Not quite there yet:
- indentation diffs: I don't really understand why, since we're applying the same `xml_to_string` to `result` and `original`
- node ordering looks different

<img width="1439" alt="Capture d’écran 2024-10-30 à 16 11 21" src="https://github.com/user-attachments/assets/408fcb52-679d-45fc-b4fa-88fa8c7c47f8">
