### PR TITLE
fix: support auth w/o token

### DIFF
--- a/isomorphe/app.py
+++ b/isomorphe/app.py
@@ -70,6 +70,10 @@ def login():
         gn_info = migrator.gn.info()
     except (requests.exceptions.RequestException, GeonetworkConnectionError) as e:
         flash(f"Problème d'authentification ({e})", "error")
+        # still record the login info for the next try
+        session["url"] = url.rstrip("/")
+        session["username"] = username
+        session["password"] = password
         return redirect(url_for("login_form"))
     else:
         authenticated = gn_info.get("me", {}).get("@authenticated", "false") == "true"

--- a/isomorphe/geonetwork.py
+++ b/isomorphe/geonetwork.py
@@ -92,7 +92,7 @@ class GeonetworkClient:
             raise GeonetworkConnectionError(
                 f"Redirection détectée vers {r.headers['Location']}. Merci d'utiliser l'URL canonique du serveur."
             )
-        # if the POST above failed, we need the XSFR-TOKEN to procede further
+        # if the POST above failed, we need the XSFR-TOKEN to proceed further
         # if it did not, (username, password) basic auth should be enough
         if not r.ok:
             xsrf_token = r.cookies.get("XSRF-TOKEN")

--- a/isomorphe/geonetwork.py
+++ b/isomorphe/geonetwork.py
@@ -92,12 +92,15 @@ class GeonetworkClient:
             raise GeonetworkConnectionError(
                 f"Redirection détectée vers {r.headers['Location']}. Merci d'utiliser l'URL canonique du serveur."
             )
-        xsrf_token = r.cookies.get("XSRF-TOKEN")
-        if xsrf_token:
-            self.session.headers.update({"X-XSRF-TOKEN": xsrf_token})
-            log.debug(f"XSRF token: {xsrf_token}")
-        else:
-            raise GeonetworkConnectionError("Impossible de récupérer le token XSRF")
+        # if the POST above failed, we need the XSFR-TOKEN to procede further
+        # if it did not, (username, password) basic auth should be enough
+        if not r.ok:
+            xsrf_token = r.cookies.get("XSRF-TOKEN")
+            if xsrf_token:
+                self.session.headers.update({"X-XSRF-TOKEN": xsrf_token})
+                log.debug("XSRF token found")
+            else:
+                raise GeonetworkConnectionError("Impossible de récupérer le token XSRF")
 
     def _get_md_type(self, md: dict) -> MetadataType:
         return MetadataType(md.get("isTemplate", MetadataType.METADATA))


### PR DESCRIPTION
Fix #107 

Some catalogs do not support the `XSRF-TOKEN` dance (because of CAS integration?), but they handle the basic auth properly (i.e. auth is enough, no need for token).

This allows us to handle both cases. "No token" case is detected when the `POST` to fetch the `XSFR-TOKEN` does _not_ fail (which means the basic auth is enough to POST on this endpoint).