### PR TITLE
fix: Off-by-one error on search result list in geonetwork v4

### DIFF
--- a/isomorphe/geonetwork.py
+++ b/isomorphe/geonetwork.py
@@ -132,9 +132,9 @@ class GeonetworkClient:
     def get_records(self, query: dict[str, Any] | None = None) -> list[Record]:
         params = self._search_params(query)
         records = []
-        to = 0
+        from_pos = 0
         while True:
-            hits = self._search_hits(params, from_pos=to + 1)
+            hits = self._search_hits(params, from_pos=from_pos)
             if not hits:
                 break
             recs = []
@@ -146,7 +146,7 @@ class GeonetworkClient:
                 else:
                     log.debug(f"Skipping empty record: {hit}")
             records += recs
-            to += len(hits)
+            from_pos += len(hits)
         return records
 
     @abc.abstractmethod
@@ -386,7 +386,7 @@ class GeonetworkClientV3(GeonetworkClient):
         r = self.session.get(
             f"{self.api}/q",
             headers={"Accept": "application/json"},
-            params=params | {"from": from_pos},
+            params=params | {"from": from_pos + 1},  # v3 'from' param starts at 1
         )
         r.raise_for_status()
         rsp = r.json()

--- a/tests/test_gn_client.py
+++ b/tests/test_gn_client.py
@@ -154,7 +154,7 @@ def test_get_records_v4(requests_mock: requests_mock.Mocker):
             "isTemplate",
             "mdStatus",
         ],
-        "from": 1,
+        "from": 0,
     }
 
 


### PR DESCRIPTION
Fix https://github.com/ecolabdata/ecospheres-isomorphe/issues/113

Search result list start position changed between Geonetwork v3 (starting from=1) and v4 (starting from=0).