### PR TITLE
fix: Remove obsolete MEF support

### DIFF
--- a/isomorphe/app.py
+++ b/isomorphe/app.py
@@ -1,5 +1,4 @@
 import difflib
-import io
 import logging
 import os
 from datetime import datetime
@@ -14,7 +13,6 @@ from flask import (
     redirect,
     render_template,
     request,
-    send_file,
     session,
     url_for,
 )
@@ -251,19 +249,6 @@ def transform_results_preview(job_id: str):
         results=results,
         uuid_filter=migrator.gn.uuid_filter([r.uuid for r in results]),
         url=url,
-    )
-
-
-@app.route("/transform/download_result/<job_id>")
-def transform_download_result(job_id: str):
-    job = get_job(job_id)
-    if not job:
-        abort(404)
-    return send_file(
-        io.BytesIO(job.result.to_mef()),
-        mimetype="application/zip",
-        download_name=f"{job_id}.zip",
-        as_attachment=True,
     )
 
 

--- a/isomorphe/migrator.py
+++ b/isomorphe/migrator.py
@@ -24,7 +24,6 @@ from isomorphe.geonetwork import (
     MetadataType,
     Record,
     WorkflowStage,
-    extract_record_info,
 )
 from isomorphe.util import xml_to_string
 
@@ -117,16 +116,11 @@ class Migrator:
         Transform data from a selection
         """
         log.info(f"Transforming {selection} via {transformation}")
-        sources = self.gn.get_sources()
 
         batch = TransformBatch[TransformBatchRecord](transformation=transformation.name)
         for r in selection:
             log.debug(f"Processing record {r.uuid}: md_type={r.md_type.name}, state={r.state}")
             original = self.gn.get_record(r.uuid)
-            # TODO: remove extract_record_info
-            # extract_record_info() mutates `original`
-            # this must happen before we store `original` in the BatchRecord
-            _ = extract_record_info(original, sources)
             batch_record = TransformBatchRecord(
                 url=self.gn.url,
                 uuid=r.uuid,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,6 +16,8 @@ GN_TEST_URL: Final = "http://localhost:57455/geonetwork/srv"
 GN_TEST_USER: Final = "admin"
 GN_TEST_PASSWORD: Final = "admin"
 
+XPATH_ISO_DATE_STAMP = "/gmd:MD_Metadata/gmd:dateStamp/gco:DateTime/text()"
+
 
 @dataclass(kw_only=True)
 class Fixture:

--- a/tests/test_gn_client.py
+++ b/tests/test_gn_client.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 import pytest
 import requests_mock
-from conftest import Fixture
+from conftest import XPATH_ISO_DATE_STAMP, Fixture
 
 from isomorphe.geonetwork import (
     GeonetworkClient,
@@ -12,7 +12,6 @@ from isomorphe.geonetwork import (
     GeonetworkConnectionError,
     MetadataType,
     Record,
-    extract_record_info,
 )
 
 GN_FAKE_URL = "http://example.com/geonetwork/srv"
@@ -62,15 +61,14 @@ def test_duplicate_uuid(
     assert new_record is not None
 
 
-def test_records_order(gn_client: GeonetworkClient):
+def test_records_order(gn_client: GeonetworkClient, clean_md_fixtures: list[Fixture]):
     """Records should be ordered by changeDate asc"""
     records = gn_client.get_records()
     assert len(records) >= 2
 
     def get_change_date_from_record(record: Record) -> str:
-        full_record = gn_client.get_record(record.uuid)
-        info = extract_record_info(full_record, sources=gn_client.get_sources())
-        return info.xpath("//changeDate/text()")[0]
+        r = gn_client.get_record(record.uuid)
+        return r.xpath(XPATH_ISO_DATE_STAMP, namespaces=r.nsmap)[0]
 
     assert records == sorted(records, key=get_change_date_from_record)
 

--- a/tests/test_migrate.py
+++ b/tests/test_migrate.py
@@ -2,16 +2,13 @@ from datetime import datetime
 from time import sleep
 from unittest.mock import patch
 
-from conftest import GN_TEST_URL, Fixture
+from conftest import GN_TEST_URL, XPATH_ISO_DATE_STAMP, Fixture
 from lxml import etree
 from test_transform import get_transform_results
 
 from isomorphe.batch import MigrateMode, SuccessTransformBatchRecord, TransformBatch
 from isomorphe.geonetwork import MetadataType
 from isomorphe.migrator import Migrator
-
-XPATH_ISO_DATE_STAMP = "/gmd:MD_Metadata/gmd:dateStamp/gco:DateTime/text()"
-XPATH_GEONET_CHANGE_DATE = "/gmd:MD_Metadata/geonet:info//changeDate/text()"
 
 
 def get_records(migrator: Migrator, md_fixtures: list[Fixture]) -> dict[str, etree._ElementTree]:
@@ -38,13 +35,12 @@ def test_migrate_change_language_overwrite(migrator: Migrator, md_fixtures: list
 
     records_after = get_records(migrator, md_fixtures)
 
-    # content has changed on original records (especially the date stamps)
+    # content has changed on original records (especially the metadata date stamp)
     for uuid in [f.uuid for f in md_fixtures]:
         assert etree.tostring(records_after[uuid]) != etree.tostring(records_before[uuid])
-        for xpath in [XPATH_ISO_DATE_STAMP, XPATH_GEONET_CHANGE_DATE]:
-            dt_before = get_datetime(records_before[uuid], xpath)
-            dt_after = get_datetime(records_after[uuid], xpath)
-            assert dt_after > dt_before
+        dt_before = get_datetime(records_before[uuid], XPATH_ISO_DATE_STAMP)
+        dt_after = get_datetime(records_after[uuid], XPATH_ISO_DATE_STAMP)
+        assert dt_after > dt_before
 
 
 def test_migrate_change_language_overwrite_preserve_date_stamp(
@@ -61,12 +57,11 @@ def test_migrate_change_language_overwrite_preserve_date_stamp(
 
     records_after = get_records(migrator, md_fixtures)
 
-    # content has changed on original records (but not the date stamps)
+    # content has changed on original records (but not the metadata date stamp)
     for uuid in [f.uuid for f in md_fixtures]:
-        for xpath in [XPATH_ISO_DATE_STAMP, XPATH_GEONET_CHANGE_DATE]:
-            dt_before = get_datetime(records_before[uuid], xpath)
-            dt_after = get_datetime(records_after[uuid], xpath)
-            assert dt_after == dt_before
+        dt_before = get_datetime(records_before[uuid], XPATH_ISO_DATE_STAMP)
+        dt_after = get_datetime(records_after[uuid], XPATH_ISO_DATE_STAMP)
+        assert dt_after == dt_before
 
 
 def test_migrate_change_language_duplicate(


### PR DESCRIPTION
Fix #32 

Note: Changed tests to rely on metadata date stamp rather than geonetwork internal info. This avoid a flag in `gn.get_record`, and makes more sense anyway.