### PR TITLE
fix: Increase diff window

### DIFF
--- a/isomorphe/app.py
+++ b/isomorphe/app.py
@@ -212,6 +212,7 @@ def transform_diff(job_id: str, uuid: str):
         fromfile=result.uuid,
         tofile=result.uuid,
         lineterm="",
+        n=10,
     )
     return render_template("diff.html.j2", diff="\n".join(diff))
 


### PR DESCRIPTION
Fix https://github.com/ecolabdata/ecospheres-isomorphe/issues/138

Ideally we'd want to scope the window around relevant XML elements, but that would mean :
- diff needs to somehow understand XML
- each transformation needs to provide scoping info

Let's start with a larger window and see if we still have cases where we miss context.