### PR TITLE
chore: Fix flaky test

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -39,4 +39,4 @@ jobs:
 
       - name: Run tests
         run: |
-          pytest tests/
+          pytest -raP tests/

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,6 +17,7 @@ GN_TEST_USER: Final = "admin"
 GN_TEST_PASSWORD: Final = "admin"
 
 XPATH_ISO_DATE_STAMP = "/gmd:MD_Metadata/gmd:dateStamp/gco:DateTime/text()"
+XPATH_GN_DATE_STAMP = "/gmd:MD_Metadata/geonet:info/changeDate/text()"
 
 
 @dataclass(kw_only=True)
@@ -90,6 +91,7 @@ def seed_fixtures(gn_client: GeonetworkClient, group_fixture: int) -> list[Fixtu
                 group=None,
                 uuid_processing="NOTHING",
             )
+            sleep(1)  # make sure each record has a different database changeDate
             fixtures.append(Fixture(uuid=uuid, name=fixture.stem, content=content))
 
     total_records = gn_client.get_records()

--- a/tests/test_gn_client.py
+++ b/tests/test_gn_client.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 import pytest
 import requests_mock
-from conftest import XPATH_ISO_DATE_STAMP, Fixture
+from conftest import XPATH_GN_DATE_STAMP, Fixture
 
 from isomorphe.geonetwork import (
     GeonetworkClient,
@@ -67,8 +67,8 @@ def test_records_order(gn_client: GeonetworkClient, clean_md_fixtures: list[Fixt
     assert len(records) >= 2
 
     def get_change_date_from_record(record: Record) -> str:
-        r = gn_client.get_record(record.uuid)
-        return r.xpath(XPATH_ISO_DATE_STAMP, namespaces=r.nsmap)[0]
+        r = gn_client.get_record(record.uuid, query={"withInfo": "true"})
+        return r.xpath(XPATH_GN_DATE_STAMP, namespaces=r.nsmap)[0]
 
     assert records == sorted(records, key=get_change_date_from_record)
 


### PR DESCRIPTION
Fix #151 

The flaky test was caused by identical `changeDate` when loading the fixtures in GeoNetwork : 
 
```
DEBUG ecospheres-isomorphe#151:
records:
- c375f298-bbc4-455b-98ad-f65a20b2e0a9 2024-09-06T10:42:13 2025-06-04T17:06:04
- 04301749-df52-4c60-a640-87948241ac67 2023-02-15T13:29:28 2025-06-04T17:06:04
sorted(records):
- 04301749-df52-4c60-a640-87948241ac67 2023-02-15T13:29:28 2025-06-04T17:06:04
- c375f298-bbc4-455b-98ad-f65a20b2e0a9 2024-09-06T10:42:13 2025-06-04T17:06:04
```

Turns out we also were using the wrong date to `sort()` the records in the test assertion :  We used `/gmd:MD_Metadata/gmd:dateStamp/gco:DateTime` (the ISO-19139 record change date), but the default records ordering (`sortBy=changeDate`, matching the default ordering in the GN UI) uses the internal _database_ change date. That internal change date is exposed in `/gmd:MD_Metadata/geonet:info/changeDate`.

For the record, if we ever want to sort by ISO-19139 record change date, that would be `sortBy=mdStatusChangeDate`.