### PR TITLE
fix: More robust Geonetwork authentication

### DIFF
--- a/isomorphe/templates/login.html.j2
+++ b/isomorphe/templates/login.html.j2
@@ -13,7 +13,7 @@
   <form method="post" action="{{ url_for('login') }}">
     <div class="fr-input-group">
       <label class="fr-label" for="query">URL du catalogue *
-        <span class="fr-hint-text">Exemple : <code>https://www.example.com/geonetwork/srv</code> ou <code>https://www.example.com/geonetwork/[PORTAIL]</code></span>
+        <span class="fr-hint-text">Exemple : <code>https://www.example.com/geonetwork/srv</code> ou <code>https://www.example.com/geonetwork/[ID_PORTAIL]</code></span>
       </label>
       <input required class="fr-input" type="url" id="url" name="url" value="{{ url }}" />
     </div>


### PR DESCRIPTION
Fix #158 

Fixing two different problems observed on GéoCatalogue : 
- https://www.geocatalogue.fr/geonetwork/srv => BRGM WAF caught the 403 returned by GeoNetwork for the "get XSRF token" initial POST request and returned a 200 with an HTML response. Fixed on BRGM side.
- https://www.geocatalogue.fr/geonetwork/7246a501-deb9-4f23-87b3-6fbd6d7ee5ce/fre => The URL shouldn't have the "/fre" part. With that part, GeoNetwork redirects to the login page. Made the error message clearer, asking the user to check the URL.

Also, split the authentication process into two different parts : 
1. Get the XSRF token through a non-authenticated POST request. Exact same as https://docs.geonetwork-opensource.org/4.4/customizing-application/misc/#example-csrf-curl.
2. If credentials are set, re-run the request with auth to check for valid creds.